### PR TITLE
Support ignoring requests cache-control/pragma headers

### DIFF
--- a/lib/Cacher.js
+++ b/lib/Cacher.js
@@ -75,7 +75,7 @@ Cacher.prototype.genCacheKey = function(req) {
 }
 
 Cacher.prototype.noCaching = false
-Cacher.prototype.ignoreClientNoCache = false
+Cacher.prototype.ignoreClientNoCache = true
 Cacher.prototype.cacheHeader = 'X-Cacher-Hit'
 
 Cacher.prototype.calcTtl = function(unit, value) {

--- a/test/testCacher.js
+++ b/test/testCacher.js
@@ -162,7 +162,8 @@ describe('Cacher', function() {
       })
     })
 
-    it('shouldnt cache when sending a no cache header', function(done) {
+    it('should be able to dynamically disable ignoring of request headers', function(done) {
+      cacher.ignoreClientNoCache = false
       supertest(app)
         .get('/long')
         .set('Cache-Control', 'no-cache')
@@ -171,6 +172,7 @@ describe('Cacher', function() {
         .expect('long')
         .expect('Content-Type', /text/)
         .end(function(err, res) {
+          cacher.ignoreClientNoCache = true
           assert.ifError(err)
           done()
         })
@@ -359,8 +361,7 @@ describe('Cacher', function() {
             })
         })
     })
-    it('should be able to ignore request cache control headers', function(done) {
-      cacher.ignoreClientNoCache = true
+    it('should ignore request cache control headers by default', function(done) {
       supertest(app)
         .get('/long')
         .expect(200)
@@ -373,7 +374,6 @@ describe('Cacher', function() {
             .expect(cacher.cacheHeader, 'true')
             .expect(200)
             .end(function(err, res) {
-              cacher.ignoreClientNoCache = false
               assert.ifError(err)
               done()
             })


### PR DESCRIPTION
Here's the PR we discussed in email for #15. It includes a test and the feature.

I still think this setting should default to `true` (like Django's and Rails' view caches) but if it doesn't, maybe there should be a warning added to the README?

Let me know!
