### PR TITLE
Implement genCacheTtl(res, origTtl). Allow override of TTL based on res.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ app.configure('development', function() {
 cacher.genCacheKey = function(req) {
   return req.path + req.header('user-agent')
 }
+
+// override cache TTL based on response
+cacher.genCacheTtl = function(res, origTtl) {
+  if (res.statusCode >= 400) {
+    return 0
+  }
+  return origTtl
+}
 ```
 
 ## Backends

--- a/lib/Cacher.js
+++ b/lib/Cacher.js
@@ -74,6 +74,10 @@ Cacher.prototype.genCacheKey = function(req) {
   return req.originalUrl
 }
 
+Cacher.prototype.genCacheTtl = function(res, origTtl) {
+  return origTtl
+}
+
 Cacher.prototype.noCaching = false
 Cacher.prototype.ignoreClientNoCache = true
 Cacher.prototype.cacheHeader = 'X-Cacher-Hit'
@@ -182,6 +186,7 @@ Cacher.prototype.buildEnd = function(res, key, staleKey, realTtl, ttl) {
   res.end = function (data) {
     appendCache(res, data)
     var cacheObject = {statusCode: res.statusCode, content: res._responseBody ? res._responseBody.toString("base64") : '', headers: res._headers}
+    ttl = self.genCacheTtl(res, ttl)
     self.client.set(key, cacheObject, realTtl, function(err) {
       if (err) {
         self.emit("error", err)

--- a/test/testCacher.js
+++ b/test/testCacher.js
@@ -86,6 +86,94 @@ describe('Cacher', function() {
     })
   })
 
+  describe('Override TTL based on response', function() {
+    var cacher = new Cacher(new Client());
+    var app = express();
+    var errorCodes = [ 400, 401, 403, 404, 500, 504 ];
+
+    app.get('/error', cacher.cache('minute'), function(req, res) {
+      var code = Number(req.param('code')) || 400;
+      res.send('kaboom', code);
+    });
+
+    beforeEach(function() {
+      // clear '/error?code=*' entries from cache before each test.
+      errorCodes.forEach(function(httpErrorStatusCode) {
+        cacher.invalidate('/error?code=' + httpErrorStatusCode);
+      });
+    });
+
+    it('should return unaltered TTL by default, regardless of response statusCode', function(done) {
+      assert.strictEqual(cacher.genCacheTtl({ statusCode: 200 }, 60), 60);
+
+      async.each(
+        errorCodes, function(httpErrorStatusCode, next) {
+          assert.strictEqual(cacher.genCacheTtl({ statusCode: httpErrorStatusCode }, 60), 60);
+
+          supertest(app)
+            .get('/error')
+            .query({ code: httpErrorStatusCode })
+            .expect(cacher.cacheHeader, 'false')
+            .expect(httpErrorStatusCode, 'kaboom')
+            .expect('Content-Type', /text/)
+            .end(function(err, res) {
+              assert.ifError(err);
+
+              supertest(app)
+                .get('/error')
+                .query({ code: httpErrorStatusCode })
+                .expect(cacher.cacheHeader, 'true') // 2nd request is cached
+                .expect(httpErrorStatusCode, 'kaboom')
+                .expect('Content-Type', /text/)
+                .end(function(err, res) {
+                  assert.ifError(err);
+                  next();
+                });
+            });
+        }, done
+      );
+    });
+
+    it('should use custom TTL on error responses when genCacheTtl is overridden', function(done) {
+      // Override TTL for error responses to be 0 (i.e. not cached).
+      cacher.genCacheTtl = function(res, origTtl) {
+        if (errorCodes.indexOf(res.statusCode) >= 0) {
+          return 0;
+        }
+        return origTtl;
+      };
+
+      assert.strictEqual(cacher.genCacheTtl({ statusCode: 200 }, 60), 60);
+
+      async.each(
+        errorCodes, function(httpErrorStatusCode, next) {
+          assert.strictEqual(cacher.genCacheTtl({ statusCode: httpErrorStatusCode }, 60), 0);
+
+          supertest(app)
+            .get('/error')
+            .query({ code: httpErrorStatusCode })
+            .expect(cacher.cacheHeader, 'false')
+            .expect(httpErrorStatusCode, 'kaboom')
+            .expect('Content-Type', /text/)
+            .end(function(err, res) {
+              assert.ifError(err);
+
+              supertest(app)
+                .get('/error')
+                .query({ code: httpErrorStatusCode })
+                .expect(cacher.cacheHeader, 'false') // 2nd request is NOT cached
+                .expect(httpErrorStatusCode, 'kaboom')
+                .expect('Content-Type', /text/)
+                .end(function(err, res) {
+                  assert.ifError(err);
+                  next();
+                });
+            });
+        }, done
+      );
+    });
+  });
+
   describe('Caching', function() {
     var cacher = new Cacher(new Client())
     var app = require("./fixtures/server")(cacher)


### PR DESCRIPTION
For issue #20 

Also has tests and example in the README
