### PR TITLE
Dont cache (set on the fly)

### DIFF
--- a/lib/Cacher.js
+++ b/lib/Cacher.js
@@ -151,8 +151,8 @@ Cacher.prototype.cache = function(unit, value) {
           return self.sendCached(res, cacheObject)
         }
 
-        self.buildEnd(res, key, staleKey, realTtl, ttl)
-        self.buildWrite(res)
+        self.buildEnd(res, key, staleKey, realTtl, ttl, req)
+        self.buildWrite(res, req)
 
         res.header(self.cacheHeader, false)
         next()
@@ -179,11 +179,15 @@ function appendCache(res, data) {
   }
 }
 
-Cacher.prototype.buildEnd = function(res, key, staleKey, realTtl, ttl) {
+Cacher.prototype.buildEnd = function(res, key, staleKey, realTtl, ttl, req) {
   var origEnd = res.end
   var self = this
 
   res.end = function (data) {
+    if (req && req.noCaching) {
+      return origEnd.apply(res, arguments)
+    }
+
     appendCache(res, data)
     var cacheObject = {statusCode: res.statusCode, content: res._responseBody ? res._responseBody.toString("base64") : '', headers: res._headers}
     ttl = self.genCacheTtl(res, ttl)
@@ -204,10 +208,12 @@ Cacher.prototype.buildEnd = function(res, key, staleKey, realTtl, ttl) {
   }
 }
 
-Cacher.prototype.buildWrite = function(res) {
+Cacher.prototype.buildWrite = function(res, req) {
   var origWrite = res.write
   res.write = function (data) {
-    appendCache(res, data)
+    if (!req || !req.noCaching) {
+      appendCache(res, data)
+    }
     return origWrite.apply(res, arguments)
   }
 }

--- a/test/fixtures/server.js
+++ b/test/fixtures/server.js
@@ -36,6 +36,11 @@ module.exports = function(cacher) {
   app.get('/head', cacher.cache('day'), function(req, res) {
     res.send('HEAD request')
   })
+  app.get('/dont-cache-onthefly', cacher.cache('day'), function(req, res) {
+    req.noCaching = true;
+    res.send('this is not cached')
+  })
+
 
   var fooRouter = express.Router();
   var barRouter = express.Router();

--- a/test/testCacher.js
+++ b/test/testCacher.js
@@ -525,5 +525,37 @@ describe('Cacher', function() {
       ])
     })
 
+    /**
+     * useful when you got some response error and dont want to cache it
+     * Example;
+     * app.get('/dont-cache-onthefly', cacher.cache('day'), function(req, res) {
+     *   req.noCaching = true;
+     *   res.send('this is not cached')
+     * })
+     */
+    it('should let you avoid cache on the fly', function(done) {
+      supertest(app)
+        .get('/dont-cache-onthefly')
+        .expect(cacher.cacheHeader, 'false')
+        .expect(200)
+        .expect('this is not cached')
+        .expect('Content-Type', /text/)
+        .end(function(err, res) {
+          assert.ifError(err)
+
+          supertest(app)
+            .get('/dont-cache-onthefly')
+            .expect(cacher.cacheHeader, 'false')
+            .expect(200)
+            .expect('this is not cached')
+            .expect('Content-Type', /text/)
+            .end(function(err, res) {
+              assert.ifError(err)
+              done()
+            })
+        })
+    })
+
+
   })
 })


### PR DESCRIPTION
Sometimes yo need to avoid cache on certains errors;

``` javascript
app.get('/dont-cache-onthefly', cacher.cache('day'), function(req, res) {
  // some complex stuff
  // if have an error response dont cache it:
    req.noCaching = true;
  // endif

  res.send(complexStuff)
})
```
